### PR TITLE
Fix yarn.lock react compile errors

### DIFF
--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -50,11 +50,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react@*":
-  version "15.0.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.34.tgz#c4f7235f3d245216a706887b7d1ffedaf5b1dc06"
-
-"@types/react@^16.0.5":
+"@types/react@*", "@types/react@^16.0.5":
   version "16.0.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.5.tgz#d713cf67cc211dea20463d2a0b66005c22070c4b"
 


### PR DESCRIPTION
Doing a fresh install with yarn results in compile errors because `@types/react:*` resolves to an earlier version than the specified 16.0.5 version. I modified the `yarn.lock` file to resolve * version to 16.0.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/piotrwitek/react-redux-typescript-guide/19)
<!-- Reviewable:end -->
