### PR TITLE
Bugfix: reference 'rxjs-imports'

### DIFF
--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 
+import './rxjs-imports';
 import store from './store';
 import {
   Home,


### PR DESCRIPTION
File `rxjs-imports.ts` is not referenced anywhere which causes the application fail to start:
```
Uncaught TypeError: action$.ofType(...).concatMap is not a function...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/piotrwitek/react-redux-typescript-guide/23)
<!-- Reviewable:end -->
