### PR TITLE
Rename ActionsUnion to ActionUnion

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,7 +869,7 @@ state.counterPairs[0].immutableCounter2 = 1; // TS Error: cannot be mutated
 
 ```tsx
 import { combineReducers } from 'redux';
-import { ActionsUnion } from 'typesafe-actions';
+import { ActionUnion } from 'typesafe-actions';
 
 import { Todo, TodosFilter } from './models';
 import * as actions from './actions';
@@ -882,7 +882,7 @@ export type TodosState = {
   readonly todosFilter: TodosFilter;
 };
 
-export type TodosAction = ActionsUnion<typeof actions>;
+export type TodosAction = ActionUnion<typeof actions>;
 
 export default combineReducers<TodosState, TodosAction>({
   isFetching: (state = false, action) => {


### PR DESCRIPTION
This has been refactored in typesafe-actions: https://github.com/piotrwitek/typesafe-actions/commit/89cbb19cd7a326908c2d00641978690218f30888