### PR TITLE
Add the example for useContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,29 @@ export default Counter;
 
 [⇧ back to top](#table-of-contents)
 
+#### - useContext
+
+> https://reactjs.org/docs/hooks-reference.html#usecontext
+
+```tsx
+import * as React from 'react';
+import ThemeContext from '../context/theme-context';
+
+interface ThemedButtonProps {}
+
+export default function ThemeToggleButton(props: ThemedButtonProps) {
+  const { theme, toggleTheme } = React.useContext(ThemeContext);
+  return (
+    <button onClick={toggleTheme} style={theme} >
+      Toggle Theme
+    </button>
+  );
+}
+
+```
+
+[⇧ back to top](#table-of-contents)
+
 ---
 
 # Redux

--- a/README.md
+++ b/README.md
@@ -834,9 +834,9 @@ export default Counter;
 import * as React from 'react';
 import ThemeContext from '../context/theme-context';
 
-interface ThemedButtonProps {}
+type Props = {};
 
-export default function ThemeToggleButton(props: ThemedButtonProps) {
+export default function ThemeToggleButton(props: Props) {
   const { theme, toggleTheme } = React.useContext(ThemeContext);
   return (
     <button onClick={toggleTheme} style={theme} >

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -320,6 +320,14 @@ Hook for state management like Redux in a function component.
 
 [⇧ back to top](#table-of-contents)
 
+#### - useContext
+
+> https://reactjs.org/docs/hooks-reference.html#usecontext
+
+::codeblock='playground/src/hooks/use-theme-context.tsx'::
+
+[⇧ back to top](#table-of-contents)
+
 ---
 
 # Redux

--- a/playground/src/context/theme-consumer.tsx
+++ b/playground/src/context/theme-consumer.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import ThemeContext from './theme-context';
 
-interface ThemedButtonProps {}
+type Props = {};
 
-export default function ToggleThemeButton(props: ThemedButtonProps) {
+export default function ToggleThemeButton(props: Props) {
   return (
     <ThemeContext.Consumer>
       {({ theme, toggleTheme }) => <button style={theme} onClick={toggleTheme} {...props} />}

--- a/playground/src/context/theme-consumer.tsx
+++ b/playground/src/context/theme-consumer.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import ThemeContext from './theme-context';
+
+interface ThemedButtonProps {}
+
+export default function ToggleThemeButton(props: ThemedButtonProps) {
+  return (
+    <ThemeContext.Consumer>
+      {({ theme, toggleTheme }) => <button style={theme} onClick={toggleTheme} {...props} />}
+    </ThemeContext.Consumer>
+  );
+}

--- a/playground/src/context/theme-context.ts
+++ b/playground/src/context/theme-context.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+export type Theme = React.CSSProperties;
+
+type Themes = {
+  dark: Theme;
+  light: Theme;
+};
+
+export const themes: Themes = {
+  dark: {
+    color: 'black',
+    backgroundColor: 'white',
+  },
+  light: {
+    color: 'white',
+    backgroundColor: 'black',
+  },
+};
+
+export type ThemeContextProps = { theme: Theme; toggleTheme?: () => void };
+const ThemeContext = React.createContext<ThemeContextProps>({ theme: themes.light });
+
+export default ThemeContext;

--- a/playground/src/context/theme-provider.tsx
+++ b/playground/src/context/theme-provider.tsx
@@ -1,23 +1,9 @@
 import React from 'react';
+import ThemeContext, { themes, Theme } from './theme-context';
+import ToggleThemeButton from './theme-consumer';
 
-// Context
-const themes = {
-  dark: {
-    color: 'black',
-    backgroundColor: 'white',
-  } as React.CSSProperties,
-  light: {
-    color: 'white',
-    backgroundColor: 'black',
-  } as React.CSSProperties,
-};
-
-type Theme = { theme: React.CSSProperties; toggleTheme?: () => void };
-const ThemeContext = React.createContext<Theme>({ theme: themes.light });
-
-// Provider
 interface State {
-  theme: Theme['theme'];
+  theme: Theme;
 }
 export class App extends React.Component<{}, State> {
   readonly state: State = { theme: themes.light };
@@ -37,15 +23,4 @@ export class App extends React.Component<{}, State> {
       </ThemeContext.Provider>
     );
   }
-}
-
-// Consumer
-interface ThemedButtonProps {}
-
-function ToggleThemeButton(props: ThemedButtonProps) {
-  return (
-    <ThemeContext.Consumer>
-      {({ theme, toggleTheme }) => <button style={theme} onClick={toggleTheme} {...props} />}
-    </ThemeContext.Consumer>
-  );
 }

--- a/playground/src/context/theme-provider.tsx
+++ b/playground/src/context/theme-provider.tsx
@@ -5,7 +5,7 @@ import ToggleThemeButton from './theme-consumer';
 interface State {
   theme: Theme;
 }
-export class App extends React.Component<{}, State> {
+export class ThemeProvider extends React.Component<{}, State> {
   readonly state: State = { theme: themes.light };
 
   toggleTheme = () => {

--- a/playground/src/hooks/use-theme-context.tsx
+++ b/playground/src/hooks/use-theme-context.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import ThemeContext from '../context/theme-context';
 
-interface ThemedButtonProps {}
+type Props = {};
 
-export default function ThemeToggleButton(props: ThemedButtonProps) {
+export default function ThemeToggleButton(props: Props) {
   const { theme, toggleTheme } = React.useContext(ThemeContext);
   return (
     <button onClick={toggleTheme} style={theme} >

--- a/playground/src/hooks/use-theme-context.tsx
+++ b/playground/src/hooks/use-theme-context.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import ThemeContext from '../context/theme-context';
+
+interface ThemedButtonProps {}
+
+export default function ThemeToggleButton(props: ThemedButtonProps) {
+  const { theme, toggleTheme } = React.useContext(ThemeContext);
+  return (
+    <button onClick={toggleTheme} style={theme} >
+      Toggle Theme
+    </button>
+  );
+}


### PR DESCRIPTION
resolve https://github.com/piotrwitek/react-redux-typescript-guide/issues/120#issuecomment-457159038

- divide `playground/src/context/theme-provider.tsx` to `theme-provider.tsx`, `theme-consumer.tsx` and  `theme-context.ts`.
- add the example for `useContext` to `playground/src/hooks/use-theme-context.tsx`.

Do you have a reason that `playground/src/context/theme-provider` have not been add to README? If you don't have any reason, I think that we should add it to README.