### PR TITLE
Fix a broken header reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,7 @@ export const add = (amount: number) => action(ADD, amount);
 // ALTERNATIVE API - allow to use reference to "action-creator" function instead of "type constant"
 // e.g. case getType(increment): return { ... }
 // This will allow to completely eliminate need for "constants" in your application, more info here:
-// https://github.com/piotrwitek/typesafe-actions#behold-the-mighty-tutorial
+// https://github.com/piotrwitek/typesafe-actions#constants
 
 // OPTION 1 (with generics):
 // import { createStandardAction } from 'typesafe-actions';

--- a/playground/src/features/counters/actions.ts
+++ b/playground/src/features/counters/actions.ts
@@ -9,7 +9,7 @@ export const add = (amount: number) => action(ADD, amount);
 // ALTERNATIVE API - allow to use reference to "action-creator" function instead of "type constant"
 // e.g. case getType(increment): return { ... }
 // This will allow to completely eliminate need for "constants" in your application, more info here:
-// https://github.com/piotrwitek/typesafe-actions#behold-the-mighty-tutorial
+// https://github.com/piotrwitek/typesafe-actions#constants
 
 // OPTION 1 (with generics):
 // import { createStandardAction } from 'typesafe-actions';


### PR DESCRIPTION
behold-the-mighty-tutorial no longer exists. Contextually, I think this probably wants to refer to the Constants header.