### PR TITLE
DOC: typofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ const handleChange: React.ReactEventHandler<HTMLInputElement> = (ev) => { ... }
 ```
 
 #### `React.XXXEvent<HTMLXXXElement>`
-Type representing more specific event handler. Some common event examples: `ChangeEvent, FormEvent, FocusEvent, KeyboardEvent, MouseEvent, DragEvent, PointerEvent, WheelEvent, TouchEvent`.
+Type representing more specific event. Some common event examples: `ChangeEvent, FormEvent, FocusEvent, KeyboardEvent, MouseEvent, DragEvent, PointerEvent, WheelEvent, TouchEvent`.
 ```tsx
 const handleChange = (ev: React.MouseEvent<HTMLDivElement>) => { ... }
 


### PR DESCRIPTION
Type representing more specific event handler. => Type representing more specific event. Resolves #182