### PR TITLE
Typo in Store Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,7 +1209,7 @@ When creating a store instance we don't need to provide any additional types. It
 > The resulting store instance methods like `getState` or `dispatch` will be type checked and will expose all type errors
 
 ```tsx
-import { RootAction, RootState, Services } from 'MyTypes';
+import { Store, RootAction, RootState, Services } from 'MyTypes';
 import { createStore, applyMiddleware } from 'redux';
 import { createEpicMiddleware } from 'redux-observable';
 import { createBrowserHistory } from 'history';
@@ -1224,7 +1224,7 @@ import services from '../services';
 export const history = createBrowserHistory();
 
 export const epicMiddleware = createEpicMiddleware<
-  RootAction,
+  Store,
   RootAction,
   RootState,
   Services


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
RootState type is added twice. I think that you meant to include Store in the types here.

## Related issues:
-NA

## Checklist

* [ ] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/react-redux-typescript-guide/blob/master/CONTRIBUTING.md)
* [ ] I have edited `README_SOURCE.md` (NOT `README.md`)
* [ ] I have run CI script locally `npm run ci-check` to generate an updated `README.md`
* [ ] I have linked all related issues above
* [ ] I have rebased my branch

