### PR TITLE
Fix outdated link in Goals-section in README (#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _Found it useful? Want more updates?_
 
 - Complete type safety (with [`--strict`](https://www.typescriptlang.org/docs/handbook/compiler-options.html) flag) without losing type information downstream through all the layers of our application (e.g. no type assertions or hacking with `any` type)
 - Make type annotations concise by eliminating redundancy in types using advanced TypeScript Language features like **Type Inference** and **Control flow analysis**
-- Reduce repetition and complexity of types with TypeScript focused [complementary libraries](#complementary-libraries)
+- Reduce repetition and complexity of types with TypeScript focused [complementary libraries](#react-redux-typescript-ecosystem)
 
 ### **React, Redux, Typescript Ecosystem**
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -33,7 +33,7 @@ _Found it useful? Want more updates?_
 
 - Complete type safety (with [`--strict`](https://www.typescriptlang.org/docs/handbook/compiler-options.html) flag) without losing type information downstream through all the layers of our application (e.g. no type assertions or hacking with `any` type)
 - Make type annotations concise by eliminating redundancy in types using advanced TypeScript Language features like **Type Inference** and **Control flow analysis**
-- Reduce repetition and complexity of types with TypeScript focused [complementary libraries](#complementary-libraries)
+- Reduce repetition and complexity of types with TypeScript focused [complementary libraries](#react-redux-typescript-ecosystem)
 
 ### **React, Redux, Typescript Ecosystem**
 


### PR DESCRIPTION
## Description
Changed the outdated link in the Goals paragraph inside the README to point to [#react-redux-typescript-ecosystem](https://github.com/piotrwitek/react-redux-typescript-guide#react-redux-typescript-ecosystem)

## Related issues:
- Resolved #219

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/react-redux-typescript-guide/blob/master/CONTRIBUTING.md)
* [X] I have edited `README_SOURCE.md` (NOT `README.md`)
* [X] I have run CI script locally `npm run ci-check` to generate an updated `README.md`
* [X] I have linked all related issues above
* [X] I have rebased my branch

