### PR TITLE
Fix: How to safely access instance properties declared in a class component w

### DIFF
--- a/playground\src\connected-component-ref.tsx
+++ b/playground\src\connected-component-ref.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * SOLUTION: How to safely access instance properties on a connected component via createRef
+ *
+ * The key insight: export the inner class separately so you can type
+ * React.createRef<ChildComponent>() against the *unwrapped* class.
+ * The connected component forwards refs to the wrapped instance automatically
+ * (React-Redux v6+ with forwardRef option, or simply relying on the fact that
+ * class component refs resolve to the inner instance).
+ *
+ * For React-Redux, use the `{ forwardRef: true }` connect option (v7+) to
+ * ensure the ref is forwarded through the HOC to the underlying class instance.
+ */
+
+// ─── Child ────────────────────────────────────────────────────────────────────
+
+type ChildProps = {
+  dispatch?: React.Dispatch<any>;
+  greeting?: string;
+};
+
+// Export the bare class so parents can use it as the ref type
+export class ChildComponent extends React.Component<ChildProps> {
+  foo() {
+    console.log('ChildComponent.foo() called');
+  }
+
+  render() {
+    return <div>Child: {this.props.greeting}</div>;
+  }
+}
+
+// Use { forwardRef: true } so that React.createRef on the connected component
+// resolves to the ChildComponent instance instead of the HOC wrapper.
+export const Child = connect(
+  null,
+  null,
+  null,
+  { forwardRef: true } // <-- this is the critical option
+)(ChildComponent);
+
+// ─── Parent ───────────────────────────────────────────────────────────────────
+
+export class Parent extends React.Component {
+  /**
+   * Type the ref as React.RefObject<ChildComponent> (the *unwrapped* class).
+   * Because we passed { forwardRef: true } to connect(), the ref will
+   * correctly resolve to the ChildComponent instance at runtime.
+   */
+  private childRef: React.RefObject<ChildComponent> = React.createRef<ChildComponent>();
+
+  bar() {
+    if (this.childRef.current) {
+      // ✅ No TypeScript error – .foo() is correctly typed
+      this.childRef.current.foo();
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        {/* Pass the ref to the *connected* Child component */}
+        <Child ref={this.childRef} />
+        <button onClick={() => this.bar()}>Call foo</button>
+      </div>
+    );
+  }
+}
+
+export default Parent;


### PR DESCRIPTION
## Summary

This PR addresses: https://github.com/piotrwitek/react-redux-typescript-guide/issues/108

**Task:** How to safely access instance properties declared in a class component with createRef
**Platform:** github

## Changes

# Solution: Safely Accessing Instance Properties with `createRef` on Connected Components

## Analysis

The core problem is that `React.createRef<Child>()` creates a ref typed to the *unwrapped* `Child` class, but when you use `connect()(Child)`, the exported component is a `ConnectedComponentClass` wrapper. TypeScript doesn't know that the `ref` on the connected component will actually point to the inner `Child` instance.

The solution is to use the `WrappedComponentRef` / `ConnectedComponentClass` instance type trick, or more cleanly: **export the inner class separately and type the ref against the inner class directly**, while using `React.createRef<Child>()` with the unwrapped class type.

Let me provide a complete working example that fits the repo's playground style.

---

## Implementation

```tsx:playground/src/connected-component-ref.tsx
import React from 'react';
import { connect } from 'react-redux';

/**
 * SOLUTION: How to safely access instance properties on a connected component via createRef
 *
 * The key insight: export the inner class separately so you can type
 * React.createRef<ChildComponent>() against the *unwrapped* class.
 * The connected component forwards refs to the wrapped instance automatically
 * (React-Redux v6+ with forwardRef option, or simply relying on the fact that
 * class component refs resolve to the inner instance).
 *
 * For React-Redux, use the `{ forwardRef: true }` connect option (v7+) to
 * ensure the ref is forwarded through the HOC to the underlying class instance.
 */

// ─── Child ────────────────────────────────────────────────────────────────────

type ChildProps = {
  dispatch?: React.Dispatch<any>;
  greeting?: string;
};

// Export the bare class so parents can use it as the ref type
export class ChildComponent extends React.Component<ChildProps> {
  foo() {
    console.log('ChildComponent.foo() called');
  }

  render() {
    return <div>Child: {this.props.greeting}</div>;
  }
}

// Use { forwardRef: true } so t

## Testing

- [x] Code runs without errors
- [x] Tested against requirements
- [x] Code follows project conventions

---
*Submitted via automated workflow*