### PR TITLE
docs: add connected generic list example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
+    - [- Redux connected generic list](#--redux-connected-generic-list)
     - [- Redux connected counter via hooks](#--redux-connected-counter-via-hooks)
     - [- Redux connected counter with `redux-thunk` integration](#--redux-connected-counter-with-redux-thunk-integration)
   - [Context](#context)
@@ -1061,7 +1062,53 @@ export default () => (
 ```
 </p></details>
 
+### - Redux connected generic list
+
+```tsx
+import Types from 'MyTypes';
+import { connect } from 'react-redux';
+
+import { GenericList } from '../components';
+import { Todo } from '../features/todos/models';
+import { getFilteredTodos } from '../features/todos/selectors';
+
+type OwnProps = {
+  itemRenderer: (item: Todo) => JSX.Element;
+};
+
+const mapStateToProps = (state: Types.RootState) => ({
+  items: getFilteredTodos(state.todos),
+});
+
+export class TodoList extends GenericList<Todo> {}
+
+export const TodoListConnected = connect<
+  ReturnType<typeof mapStateToProps>,
+  {},
+  OwnProps,
+  Types.RootState
+>(mapStateToProps)(TodoList);
+
+```
+<details><summary><i>Click to expand</i></summary><p>
+
+```tsx
+import * as React from 'react';
+
+import { TodoListConnected } from '.';
+
+export default () => (
+  <TodoListConnected
+    itemRenderer={item => <div key={item.id}>{item.title}</div>}
+  />
+);
+
+```
+</p></details>
+
 [⇧ back to top](#table-of-contents)
+
+---
 
 ### - Redux connected counter via hooks
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -111,6 +111,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
+    - [- Redux connected generic list](#--redux-connected-generic-list)
     - [- Redux connected counter via hooks](#--redux-connected-counter-via-hooks)
     - [- Redux connected counter with `redux-thunk` integration](#--redux-connected-counter-with-redux-thunk-integration)
   - [Context](#context)
@@ -454,7 +455,19 @@ Adds error handling using componentDidCatch to any component
 ::codeblock='playground/src/connected/fc-counter-connected-own-props.tsx'::
 ::expander='playground/src/connected/fc-counter-connected-own-props.usage.tsx'::
 
+### - Redux connected generic list
+
+::codeblock='playground/src/connected/generic-list-connected.tsx'::
+
+<details><summary><i>Click to expand</i></summary><p>
+
+::codeblock='playground/src/connected/generic-list-connected.usage.tsx'::
+
+</p></details>
+
 [⇧ back to top](#table-of-contents)
+
+---
 
 ### - Redux connected counter via hooks
 

--- a/playground/src/connected/generic-list-connected.md
+++ b/playground/src/connected/generic-list-connected.md
@@ -1,0 +1,11 @@
+Usage:
+```jsx { "filePath": "./generic-list-connected.usage.tsx" }
+```
+
+Usage Demo:
+```jsx
+const Demo = require('./generic-list-connected.usage').default;
+<Demo />
+```
+
+[⇦ back to guide](https://github.com/piotrwitek/react-redux-typescript-guide#redux-connected-components)

--- a/playground/src/connected/generic-list-connected.tsx
+++ b/playground/src/connected/generic-list-connected.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Types from 'MyTypes';
+import { connect } from 'react-redux';
+
+import { GenericList } from '../components';
+import { Todo } from '../features/todos/models';
+import { getFilteredTodos } from '../features/todos/selectors';
+
+type OwnProps = {
+  itemRenderer: (item: Todo) => JSX.Element;
+};
+
+const mapStateToProps = (state: Types.RootState) => ({
+  items: getFilteredTodos(state.todos),
+});
+
+export class TodoList extends GenericList<Todo> {}
+
+export const TodoListConnected = connect<
+  ReturnType<typeof mapStateToProps>,
+  {},
+  OwnProps,
+  Types.RootState
+>(mapStateToProps)(TodoList);

--- a/playground/src/connected/generic-list-connected.usage.tsx
+++ b/playground/src/connected/generic-list-connected.usage.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import { TodoListConnected } from '.';
+
+export default () => (
+  <TodoListConnected
+    itemRenderer={item => <div key={item.id}>{item.title}</div>}
+  />
+);

--- a/playground/src/connected/index.ts
+++ b/playground/src/connected/index.ts
@@ -1,3 +1,4 @@
 export * from './fc-counter-connected-bind-action-creators';
 export * from './fc-counter-connected-own-props';
 export * from './fc-counter-connected';
+export * from './generic-list-connected';

--- a/playground/src/routes/home.tsx
+++ b/playground/src/routes/home.tsx
@@ -5,6 +5,7 @@ import FCSpreadAttributesUsage from '../components/fc-spread-attributes.usage';
 import ClassCounterUsage from '../components/class-counter.usage';
 import ClassCounterWithDefaultPropsUsage from '../components/class-counter-with-default-props.usage';
 import UserListUsage from '../components/generic-list.usage';
+import GenericListConnectedUsage from '../connected/generic-list-connected.usage';
 import WithErrorBoundaryUsage from '../hoc/with-error-boundary.usage';
 import WithStateUsage from '../hoc/with-state.usage';
 import WithConnectedCountUsage from '../hoc/with-connected-count.usage';
@@ -18,6 +19,7 @@ export function Home() {
       <ClassCounterUsage />
       <ClassCounterWithDefaultPropsUsage />
       <UserListUsage />
+      <GenericListConnectedUsage />
       <WithErrorBoundaryUsage />
       <WithStateUsage />
       <WithConnectedCountUsage />


### PR DESCRIPTION
Adds a connected generic list example to the guide. Fixes piotrwitek/react-redux-typescript-guide#55.