### PR TITLE
docs: show refs for connected class components

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Selectors with `reselect`](#selectors-with-reselect)
   - [Connect with `react-redux`](#connect-with-react-redux)
     - [Typing connected component](#typing-connected-component)
+    - [Accessing the wrapped class instance with a ref](#accessing-the-wrapped-class-instance-with-a-ref)
     - [Typing `useSelector` and `useDispatch`](#typing-useselector-and-usedispatch)
     - [Typing connected component with `redux-thunk` integration](#typing-connected-component-with-redux-thunk-integration)
 - [Configuration & Dev Tools](#configuration--dev-tools)
@@ -1813,6 +1814,85 @@ const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
   bindActionCreators<ActionCreatorsMapObject<Types.RootAction>>({
     invalidActionCreator: () => 1, // Error: Type 'number' is not assignable to type '{ type: "todos/ADD"; payload: Todo; } | { ... }
   }, dispatch);
+
+```
+
+[⇧ back to top](#table-of-contents)
+
+### Accessing the wrapped class instance with a ref
+
+When a class component is wrapped with `connect()`, a ref points to the connected wrapper by default. Enable `forwardRef` and type the connected component with `React.RefAttributes` when the parent needs to call public methods on the wrapped class instance.
+
+```tsx
+import * as React from 'react';
+import Types from 'MyTypes';
+import { connect } from 'react-redux';
+
+import { countersSelectors } from '../features/counters';
+
+type OwnProps = {
+  label: string;
+};
+
+type StateProps = {
+  count: number;
+};
+
+type Props = OwnProps & StateProps;
+
+export class ClassCounterWithHandle extends React.Component<Props> {
+  private readonly root = React.createRef<HTMLDivElement>();
+
+  focus = () => {
+    this.root.current?.focus();
+  };
+
+  render() {
+    const { count, label } = this.props;
+
+    return (
+      <div ref={this.root} tabIndex={-1}>
+        {label}: {count}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state: Types.RootState): StateProps => ({
+  count: countersSelectors.getReduxCounter(state.counters),
+});
+
+type ConnectedCounterProps = OwnProps &
+  React.RefAttributes<ClassCounterWithHandle>;
+
+export const ClassCounterWithHandleConnected = connect(
+  mapStateToProps,
+  null,
+  null,
+  { forwardRef: true }
+)(ClassCounterWithHandle) as React.ComponentType<ConnectedCounterProps>;
+
+export class ClassCounterWithHandleParent extends React.Component {
+  private readonly counterRef = React.createRef<ClassCounterWithHandle>();
+
+  handleFocus = () => {
+    this.counterRef.current?.focus();
+  };
+
+  render() {
+    return (
+      <div>
+        <ClassCounterWithHandleConnected
+          ref={this.counterRef}
+          label="Connected class counter"
+        />
+        <button type="button" onClick={this.handleFocus}>
+          Focus counter
+        </button>
+      </div>
+    );
+  }
+}
 
 ```
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -134,6 +134,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Selectors with `reselect`](#selectors-with-reselect)
   - [Connect with `react-redux`](#connect-with-react-redux)
     - [Typing connected component](#typing-connected-component)
+    - [Accessing the wrapped class instance with a ref](#accessing-the-wrapped-class-instance-with-a-ref)
     - [Typing `useSelector` and `useDispatch`](#typing-useselector-and-usedispatch)
     - [Typing connected component with `redux-thunk` integration](#typing-connected-component-with-redux-thunk-integration)
 - [Configuration & Dev Tools](#configuration--dev-tools)
@@ -709,6 +710,14 @@ const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
   }, dispatch);
 
 ```
+
+[⇧ back to top](#table-of-contents)
+
+### Accessing the wrapped class instance with a ref
+
+When a class component is wrapped with `connect()`, a ref points to the connected wrapper by default. Enable `forwardRef` and type the connected component with `React.RefAttributes` when the parent needs to call public methods on the wrapped class instance.
+
+::codeblock='playground/src/connected/class-counter-with-ref.tsx'::
 
 [⇧ back to top](#table-of-contents)
 

--- a/playground/src/connected/class-counter-with-ref.tsx
+++ b/playground/src/connected/class-counter-with-ref.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import Types from 'MyTypes';
+import { connect } from 'react-redux';
+
+import { countersSelectors } from '../features/counters';
+
+type OwnProps = {
+  label: string;
+};
+
+type StateProps = {
+  count: number;
+};
+
+type Props = OwnProps & StateProps;
+
+export class ClassCounterWithHandle extends React.Component<Props> {
+  private readonly root = React.createRef<HTMLDivElement>();
+
+  focus = () => {
+    this.root.current?.focus();
+  };
+
+  render() {
+    const { count, label } = this.props;
+
+    return (
+      <div ref={this.root} tabIndex={-1}>
+        {label}: {count}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state: Types.RootState): StateProps => ({
+  count: countersSelectors.getReduxCounter(state.counters),
+});
+
+type ConnectedCounterProps = OwnProps &
+  React.RefAttributes<ClassCounterWithHandle>;
+
+export const ClassCounterWithHandleConnected = connect(
+  mapStateToProps,
+  null,
+  null,
+  { forwardRef: true }
+)(ClassCounterWithHandle) as React.ComponentType<ConnectedCounterProps>;
+
+export class ClassCounterWithHandleParent extends React.Component {
+  private readonly counterRef = React.createRef<ClassCounterWithHandle>();
+
+  handleFocus = () => {
+    this.counterRef.current?.focus();
+  };
+
+  render() {
+    return (
+      <div>
+        <ClassCounterWithHandleConnected
+          ref={this.counterRef}
+          label="Connected class counter"
+        />
+        <button type="button" onClick={this.handleFocus}>
+          Focus counter
+        </button>
+      </div>
+    );
+  }
+}

--- a/playground/src/connected/index.ts
+++ b/playground/src/connected/index.ts
@@ -1,3 +1,4 @@
 export * from './fc-counter-connected-bind-action-creators';
 export * from './fc-counter-connected-own-props';
 export * from './fc-counter-connected';
+export * from './class-counter-with-ref';


### PR DESCRIPTION
## Summary

- Adds a typed example for accessing a wrapped class component instance when the component is wrapped with `react-redux` `connect()`.
- Shows `forwardRef: true` plus a ref-aware connected component type so a parent can safely call a public method through `React.createRef`.
- Regenerates `README.md` from `README_SOURCE.md`.

Fixes #108

## Checks

- `npm run ci-check`
- `cd playground && npm run tsc`
- `cd playground && npm run lint -- --quiet`
