### PR TITLE
docs: show typed dispatch props for connected components

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
+    - [- Redux connected counter with typed dispatch props](#--redux-connected-counter-with-typed-dispatch-props)
     - [- Redux connected counter via hooks](#--redux-connected-counter-via-hooks)
     - [- Redux connected counter with `redux-thunk` integration](#--redux-connected-counter-with-redux-thunk-integration)
   - [Context](#context)
@@ -1056,6 +1057,87 @@ export default () => (
     label={'FCCounterConnectedOwnProps'}
     initialCount={10}
   />
+);
+
+```
+</p></details>
+
+[⇧ back to top](#table-of-contents)
+
+### - Redux connected counter with typed dispatch props
+
+Use `typeof` to bind dispatch prop types to the action creators they expose.
+This keeps the connected component props in sync with action creator signatures.
+
+```tsx
+import Types from 'MyTypes';
+import { connect } from 'react-redux';
+import * as React from 'react';
+
+import { countersActions } from '../features/counters';
+
+type OwnProps = {
+  label: string;
+};
+
+type StateProps = {
+  count: number;
+};
+
+const dispatchProps = {
+  onIncrement: countersActions.increment,
+  onAdd: countersActions.add,
+};
+
+type DispatchProps = typeof dispatchProps;
+
+type Props = OwnProps & StateProps & DispatchProps;
+
+const FCCounterWithTypedDispatch: React.FC<Props> = props => {
+  const { label, count, onAdd, onIncrement } = props;
+
+  const handleIncrement = () => {
+    onIncrement();
+  };
+
+  const handleAdd = () => {
+    onAdd(5);
+  };
+
+  return (
+    <div>
+      <span>
+        {label}: {count}
+      </span>
+      <button type="button" onClick={handleIncrement}>
+        {`Increment`}
+      </button>
+      <button type="button" onClick={handleAdd}>
+        {`Add 5`}
+      </button>
+    </div>
+  );
+};
+
+const mapStateToProps = (state: Types.RootState): StateProps => ({
+  count: state.counters.reduxCounter,
+});
+
+export const FCCounterConnectedDispatchProps = connect(
+  mapStateToProps,
+  dispatchProps
+)(FCCounterWithTypedDispatch);
+
+```
+<details><summary><i>Click to expand</i></summary><p>
+
+```tsx
+import * as React from 'react';
+
+import { FCCounterConnectedDispatchProps } from '.';
+
+export default () => (
+  <FCCounterConnectedDispatchProps label={'FCCounterConnectedDispatchProps'} />
 );
 
 ```

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -111,6 +111,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
+    - [- Redux connected counter with typed dispatch props](#--redux-connected-counter-with-typed-dispatch-props)
     - [- Redux connected counter via hooks](#--redux-connected-counter-via-hooks)
     - [- Redux connected counter with `redux-thunk` integration](#--redux-connected-counter-with-redux-thunk-integration)
   - [Context](#context)
@@ -453,6 +454,16 @@ Adds error handling using componentDidCatch to any component
 
 ::codeblock='playground/src/connected/fc-counter-connected-own-props.tsx'::
 ::expander='playground/src/connected/fc-counter-connected-own-props.usage.tsx'::
+
+[⇧ back to top](#table-of-contents)
+
+### - Redux connected counter with typed dispatch props
+
+Use `typeof` to bind dispatch prop types to the action creators they expose.
+This keeps the connected component props in sync with action creator signatures.
+
+::codeblock='playground/src/connected/fc-counter-connected-dispatch-props.tsx'::
+::expander='playground/src/connected/fc-counter-connected-dispatch-props.usage.tsx'::
 
 [⇧ back to top](#table-of-contents)
 

--- a/playground/src/connected/fc-counter-connected-dispatch-props.tsx
+++ b/playground/src/connected/fc-counter-connected-dispatch-props.tsx
@@ -1,0 +1,57 @@
+import Types from 'MyTypes';
+import { connect } from 'react-redux';
+import * as React from 'react';
+
+import { countersActions } from '../features/counters';
+
+type OwnProps = {
+  label: string;
+};
+
+type StateProps = {
+  count: number;
+};
+
+const dispatchProps = {
+  onIncrement: countersActions.increment,
+  onAdd: countersActions.add,
+};
+
+type DispatchProps = typeof dispatchProps;
+
+type Props = OwnProps & StateProps & DispatchProps;
+
+const FCCounterWithTypedDispatch: React.FC<Props> = props => {
+  const { label, count, onAdd, onIncrement } = props;
+
+  const handleIncrement = () => {
+    onIncrement();
+  };
+
+  const handleAdd = () => {
+    onAdd(5);
+  };
+
+  return (
+    <div>
+      <span>
+        {label}: {count}
+      </span>
+      <button type="button" onClick={handleIncrement}>
+        {`Increment`}
+      </button>
+      <button type="button" onClick={handleAdd}>
+        {`Add 5`}
+      </button>
+    </div>
+  );
+};
+
+const mapStateToProps = (state: Types.RootState): StateProps => ({
+  count: state.counters.reduxCounter,
+});
+
+export const FCCounterConnectedDispatchProps = connect(
+  mapStateToProps,
+  dispatchProps
+)(FCCounterWithTypedDispatch);

--- a/playground/src/connected/fc-counter-connected-dispatch-props.usage.tsx
+++ b/playground/src/connected/fc-counter-connected-dispatch-props.usage.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import { FCCounterConnectedDispatchProps } from '.';
+
+export default () => (
+  <FCCounterConnectedDispatchProps label={'FCCounterConnectedDispatchProps'} />
+);

--- a/playground/src/connected/index.ts
+++ b/playground/src/connected/index.ts
@@ -1,3 +1,4 @@
 export * from './fc-counter-connected-bind-action-creators';
+export * from './fc-counter-connected-dispatch-props';
 export * from './fc-counter-connected-own-props';
 export * from './fc-counter-connected';


### PR DESCRIPTION
Fixes #45

IssueHunt bounty: https://oss.issuehunt.io/r/piotrwitek/react-redux-typescript-guide/issues/45

## What changed
- Add a connected counter example that types dispatch props with `typeof countersActions.increment` and `typeof countersActions.add`.
- Show the object shorthand `dispatchProps` pattern while keeping prop signatures tied to the original action creators.
- Add the usage snippet and regenerate README docs.

## Tested
- `npm run ci-check`
- `cd playground && npm run tsc`
- `cd playground && npm run lint -- --quiet`
- `cd playground && CI=true npm test -- --watchAll=false`
- `git diff --check`