### PR TITLE
docs: add scalable application structure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Store Configuration](#store-configuration)
     - [Create Global Store Types](#create-global-store-types)
     - [Create Store](#create-store)
+  - [Scalable Application Structure](#scalable-application-structure)
+    - [Feature public API](#feature-public-api)
+    - [Root composition](#root-composition)
+    - [Dependency direction](#dependency-direction)
   - [Action Creators 🌟](#action-creators-)
   - [Reducers](#reducers)
     - [State with Type-level Immutability](#state-with-type-level-immutability)
@@ -1359,6 +1363,128 @@ epicMiddleware.run(rootEpic);
 export default store;
 
 ```
+
+---
+
+## Scalable Application Structure
+
+The playground follows a feature-first structure. Each feature owns its actions,
+reducer, selectors, models and side-effects, then exposes only a small public API
+from its `index.ts` file.
+
+```ts
+src/
+|-- components/          # reusable presentational components
+|-- connected/           # react-redux bindings for components
+|-- features/
+|   |-- counters/
+|   |   |-- actions.ts
+|   |   |-- constants.ts
+|   |   |-- index.ts
+|   |   |-- reducer.ts
+|   |   `-- selectors.ts
+|   `-- todos/
+|       |-- actions.ts
+|       |-- epics.ts
+|       |-- index.ts
+|       |-- models.ts
+|       |-- reducer.ts
+|       `-- selectors.ts
+`-- store/               # root composition only
+```
+
+### Feature public API
+
+Import feature APIs through the feature entry point instead of importing from
+internal files in consumers. This keeps refactors local to the feature folder.
+
+```tsx
+import * as countersConstants from './constants';
+import * as countersActions from './actions';
+import countersReducer from './reducer';
+import * as countersSelectors from './selectors';
+
+export {
+  countersConstants,
+  countersActions,
+  countersSelectors,
+  countersReducer,
+};
+
+```
+```tsx
+// public API
+import * as todosConstants from './constants';
+import * as todosActions from './actions';
+import * as todosEpics from './epics';
+import todosReducer from './reducer';
+import * as todosSelectors from './selectors';
+export { todosConstants, todosActions, todosEpics, todosSelectors, todosReducer };
+
+```
+
+[⇧ back to top](#table-of-contents)
+
+### Root composition
+
+The store folder composes feature modules into root types, root reducer and root
+epic. Feature code does not need to import root store internals.
+
+```tsx
+import { todosActions } from '../features/todos';
+import { countersActions } from '../features/counters';
+import { routerActions } from '@lagunovsky/redux-react-router'
+
+export default {
+  router: routerActions,
+  todos: todosActions,
+  counters: countersActions,
+};
+
+```
+```tsx
+import { combineReducers } from 'redux';
+
+import { countersReducer } from '../features/counters';
+import { todosReducer } from '../features/todos';
+import { routerReducer } from './redux-router';
+
+const rootReducer = combineReducers({
+  router: routerReducer,
+  todos: todosReducer,
+  counters: countersReducer,
+});
+
+export default rootReducer;
+
+```
+```tsx
+import { combineEpics } from 'redux-observable';
+
+import { todosEpics } from '../features/todos';
+
+export default combineEpics(...Object.values(todosEpics));
+
+```
+
+[⇧ back to top](#table-of-contents)
+
+### Dependency direction
+
+Keep dependencies flowing from app-level composition into features and from
+connected components into feature public APIs:
+
+```ts
+components -> models
+connected -> components + features/*/index.ts
+features -> local models + local constants
+store -> features/*/index.ts + feature reducers/epics
+```
+
+This preserves type inference while avoiding a single large "ducks" file that
+mixes actions, reducer, selectors and effects into one module.
+
+[⇧ back to top](#table-of-contents)
 
 ---
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -122,6 +122,10 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Store Configuration](#store-configuration)
     - [Create Global Store Types](#create-global-store-types)
     - [Create Store](#create-store)
+  - [Scalable Application Structure](#scalable-application-structure)
+    - [Feature public API](#feature-public-api)
+    - [Root composition](#root-composition)
+    - [Dependency direction](#dependency-direction)
   - [Action Creators 🌟](#action-creators-)
   - [Reducers](#reducers)
     - [State with Type-level Immutability](#state-with-type-level-immutability)
@@ -524,6 +528,73 @@ When creating a store instance we don't need to provide any additional types. It
 > The resulting store instance methods like `getState` or `dispatch` will be type checked and will expose all type errors
 
 ::codeblock='playground/src/store/store.ts'::
+
+---
+
+## Scalable Application Structure
+
+The playground follows a feature-first structure. Each feature owns its actions,
+reducer, selectors, models and side-effects, then exposes only a small public API
+from its `index.ts` file.
+
+```ts
+src/
+|-- components/          # reusable presentational components
+|-- connected/           # react-redux bindings for components
+|-- features/
+|   |-- counters/
+|   |   |-- actions.ts
+|   |   |-- constants.ts
+|   |   |-- index.ts
+|   |   |-- reducer.ts
+|   |   `-- selectors.ts
+|   `-- todos/
+|       |-- actions.ts
+|       |-- epics.ts
+|       |-- index.ts
+|       |-- models.ts
+|       |-- reducer.ts
+|       `-- selectors.ts
+`-- store/               # root composition only
+```
+
+### Feature public API
+
+Import feature APIs through the feature entry point instead of importing from
+internal files in consumers. This keeps refactors local to the feature folder.
+
+::codeblock='playground/src/features/counters/index.ts'::
+::codeblock='playground/src/features/todos/index.ts'::
+
+[⇧ back to top](#table-of-contents)
+
+### Root composition
+
+The store folder composes feature modules into root types, root reducer and root
+epic. Feature code does not need to import root store internals.
+
+::codeblock='playground/src/store/root-action.ts'::
+::codeblock='playground/src/store/root-reducer.ts'::
+::codeblock='playground/src/store/root-epic.ts'::
+
+[⇧ back to top](#table-of-contents)
+
+### Dependency direction
+
+Keep dependencies flowing from app-level composition into features and from
+connected components into feature public APIs:
+
+```ts
+components -> models
+connected -> components + features/*/index.ts
+features -> local models + local constants
+store -> features/*/index.ts + feature reducers/epics
+```
+
+This preserves type inference while avoiding a single large "ducks" file that
+mixes actions, reducer, selectors and effects into one module.
+
+[⇧ back to top](#table-of-contents)
 
 ---
 

--- a/playground/src/features/todos/index.ts
+++ b/playground/src/features/todos/index.ts
@@ -1,6 +1,7 @@
 // public API
 import * as todosConstants from './constants';
 import * as todosActions from './actions';
+import * as todosEpics from './epics';
 import todosReducer from './reducer';
 import * as todosSelectors from './selectors';
-export { todosConstants, todosActions, todosSelectors, todosReducer };
+export { todosConstants, todosActions, todosEpics, todosSelectors, todosReducer };

--- a/playground/src/store/root-action.ts
+++ b/playground/src/store/root-action.ts
@@ -1,5 +1,5 @@
-import * as todosActions from '../features/todos/actions';
-import * as countersActions from '../features/counters/actions';
+import { todosActions } from '../features/todos';
+import { countersActions } from '../features/counters';
 import { routerActions } from '@lagunovsky/redux-react-router'
 
 export default {

--- a/playground/src/store/root-epic.ts
+++ b/playground/src/store/root-epic.ts
@@ -1,5 +1,5 @@
 import { combineEpics } from 'redux-observable';
 
-import * as todosEpics from '../features/todos/epics';
+import { todosEpics } from '../features/todos';
 
 export default combineEpics(...Object.values(todosEpics));

--- a/playground/src/store/root-reducer.ts
+++ b/playground/src/store/root-reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 
-import countersReducer from '../features/counters/reducer';
-import todosReducer from '../features/todos/reducer';
+import { countersReducer } from '../features/counters';
+import { todosReducer } from '../features/todos';
 import { routerReducer } from './redux-router';
 
 const rootReducer = combineReducers({


### PR DESCRIPTION
Fixes #42

IssueHunt bounty: https://oss.issuehunt.io/r/piotrwitek/react-redux-typescript-guide/issues/42

## What changed
- Add a new "Scalable Application Structure" section before the Redux feature examples.
- Document the playground's feature-first folder layout, feature public API pattern, root composition files, and dependency direction.
- Link the section to existing playground source files and regenerate README docs.

## Tested
- `npm run ci-check`
- `git diff --check`