### PR TITLE
docs: add source-backed Recompose TypeScript examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
     - [- HOC wrapping a component](#--hoc-wrapping-a-component)
     - [- HOC wrapping a component and injecting props](#--hoc-wrapping-a-component-and-injecting-props)
     - [- Nested HOC - wrapping a component, injecting props and connecting to redux 🌟](#--nested-hoc---wrapping-a-component-injecting-props-and-connecting-to-redux-)
+    - [- Legacy Recompose examples](#--legacy-recompose-examples)
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
@@ -967,6 +968,154 @@ const FCCounterWithConnectedCount = withConnectedCount(FCCounter);
 
 export default () => (
   <FCCounterWithConnectedCount overrideCount={5} label={'FCCounterWithState'} />
+);
+
+```
+</p></details>
+
+[⇧ back to top](#table-of-contents)
+
+### - Legacy Recompose examples
+
+[`recompose`](https://github.com/acdlite/recompose) is no longer actively maintained.
+Prefer [Hooks](#hooks) for new code and use these examples when maintaining or migrating older HOC-based code.
+For projects that already depend on `recompose`, install the matching type declarations with `npm i -D @types/recompose`.
+
+The examples keep consumer props separate from props injected by `compose`, `withState`, `withHandlers`, `withProps`, and `withStateHandlers`.
+
+```tsx
+import * as React from 'react';
+import { compose, withHandlers, withProps, withState, withStateHandlers } from 'recompose';
+
+type CounterOuterProps = {
+  title: string;
+  initialCount?: number;
+  step?: number;
+};
+
+type CounterStateProps = {
+  count: number;
+  setCount: (count: number) => number;
+};
+
+type CounterHandlers = {
+  onIncrement: () => void;
+  onReset: () => void;
+};
+
+type CounterLabelProps = {
+  label: string;
+};
+
+type CounterProps = CounterOuterProps & CounterStateProps & CounterHandlers & CounterLabelProps;
+
+const CounterView: React.FC<CounterProps> = ({ count, label, onIncrement, onReset }) => (
+  <section>
+    <h3>{label}</h3>
+    <p>Current count: {count}</p>
+    <button type="button" onClick={onIncrement}>
+      Increment
+    </button>
+    <button type="button" onClick={onReset}>
+      Reset
+    </button>
+  </section>
+);
+
+const withCounterState = withState<CounterOuterProps, number, 'count', 'setCount'>(
+  'count',
+  'setCount',
+  ({ initialCount = 0 }) => initialCount
+);
+
+const withCounterHandlers = withHandlers<CounterOuterProps & CounterStateProps, CounterHandlers>({
+  onIncrement:
+    ({ count, setCount, step = 1 }) =>
+    () => {
+      setCount(count + step);
+    },
+  onReset:
+    ({ initialCount = 0, setCount }) =>
+    () => {
+      setCount(initialCount);
+    },
+});
+
+const withCounterLabel = withProps<
+  CounterLabelProps,
+  CounterOuterProps & CounterStateProps & CounterHandlers
+>(({ count, title }) => ({
+  label: `${title}: ${count}`,
+}));
+
+const enhanceCounter = compose<CounterProps, CounterOuterProps>(
+  withCounterState,
+  withCounterHandlers,
+  withCounterLabel
+);
+
+export const RecomposeCounter = enhanceCounter(CounterView);
+
+type ToggleOuterProps = {
+  label: string;
+  initiallyOpen?: boolean;
+};
+
+type ToggleState = {
+  isOpen: boolean;
+};
+
+type ToggleUpdaters = {
+  toggle: () => Partial<ToggleState>;
+  close: () => Partial<ToggleState>;
+};
+
+type ToggleProps = ToggleOuterProps & ToggleState & ToggleUpdaters;
+
+const ToggleView: React.FC<ToggleProps> = ({ close, isOpen, label, toggle }) => (
+  <section>
+    <button type="button" onClick={toggle}>
+      {label}
+    </button>
+    {isOpen && (
+      <button type="button" onClick={close}>
+        Close
+      </button>
+    )}
+  </section>
+);
+
+const withToggleState = withStateHandlers<ToggleState, ToggleUpdaters, ToggleOuterProps>(
+  ({ initiallyOpen = false }) => ({
+    isOpen: initiallyOpen,
+  }),
+  {
+    toggle:
+      ({ isOpen }) =>
+      () => ({
+        isOpen: !isOpen,
+      }),
+    close: () => () => ({
+      isOpen: false,
+    }),
+  }
+);
+
+export const RecomposeToggle = withToggleState(ToggleView);
+
+```
+<details><summary><i>Click to expand</i></summary><p>
+
+```tsx
+import * as React from 'react';
+
+import { RecomposeCounter, RecomposeToggle } from './recompose-examples';
+
+export default () => (
+  <>
+    <RecomposeCounter title="Recompose counter" initialCount={3} step={2} />
+    <RecomposeToggle label="Show details" initiallyOpen />
+  </>
 );
 
 ```

--- a/README.md
+++ b/README.md
@@ -995,7 +995,7 @@ type CounterOuterProps = {
 
 type CounterStateProps = {
   count: number;
-  setCount: (count: number) => number;
+  setCount: (count: number) => void;
 };
 
 type CounterHandlers = {

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -108,6 +108,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
     - [- HOC wrapping a component](#--hoc-wrapping-a-component)
     - [- HOC wrapping a component and injecting props](#--hoc-wrapping-a-component-and-injecting-props)
     - [- Nested HOC - wrapping a component, injecting props and connecting to redux 🌟](#--nested-hoc---wrapping-a-component-injecting-props-and-connecting-to-redux-)
+    - [- Legacy Recompose examples](#--legacy-recompose-examples)
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
@@ -435,6 +436,19 @@ Adds error handling using componentDidCatch to any component
 
 ::codeblock='playground/src/hoc/with-connected-count.tsx'::
 ::expander='playground/src/hoc/with-connected-count.usage.tsx'::
+
+[⇧ back to top](#table-of-contents)
+
+### - Legacy Recompose examples
+
+[`recompose`](https://github.com/acdlite/recompose) is no longer actively maintained.
+Prefer [Hooks](#hooks) for new code and use these examples when maintaining or migrating older HOC-based code.
+For projects that already depend on `recompose`, install the matching type declarations with `npm i -D @types/recompose`.
+
+The examples keep consumer props separate from props injected by `compose`, `withState`, `withHandlers`, `withProps`, and `withStateHandlers`.
+
+::codeblock='playground/src/hoc/recompose-examples.tsx'::
+::expander='playground/src/hoc/recompose-examples.usage.tsx'::
 
 [⇧ back to top](#table-of-contents)
 

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "18.0.3",
         "@types/react-redux": "7.1.24",
         "@types/react-router-dom": "5.3.3",
+        "@types/recompose": "0.30.15",
         "axios": "0.26.1",
         "cuid": "2.1.8",
         "react": "18.1.0",
@@ -9534,6 +9535,16 @@
       "integrity": "sha512-cTf8tCem0c8A7CERYbTuF+bRFaqYu7N7HLCa6ZhUhDx8XnUsTpGx5udMWljt87JpciUKuUkImKPEsy6kcKhrcQ==",
       "dev": true,
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/recompose": {
+      "version": "0.30.15",
+      "resolved": "https://registry.npmjs.org/@types/recompose/-/recompose-0.30.15.tgz",
+      "integrity": "sha512-glX9JbRTG4WSaWxDrsHlinoRC1YRb0vNr+ocPBgBTJgMawkYx8fqwuduahzy25XBSc3xfG/k9b5XPyW6FuHVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },
@@ -37652,6 +37663,15 @@
       "integrity": "sha512-cTf8tCem0c8A7CERYbTuF+bRFaqYu7N7HLCa6ZhUhDx8XnUsTpGx5udMWljt87JpciUKuUkImKPEsy6kcKhrcQ==",
       "dev": true,
       "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/recompose": {
+      "version": "0.30.15",
+      "resolved": "https://registry.npmjs.org/@types/recompose/-/recompose-0.30.15.tgz",
+      "integrity": "sha512-glX9JbRTG4WSaWxDrsHlinoRC1YRb0vNr+ocPBgBTJgMawkYx8fqwuduahzy25XBSc3xfG/k9b5XPyW6FuHVkw==",
+      "requires": {
+        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },

--- a/playground/package.json
+++ b/playground/package.json
@@ -29,6 +29,7 @@
     "@types/node": "16.11.33",
     "@types/react": "18.0.8",
     "@types/react-dom": "18.0.3",
+    "@types/recompose": "0.30.15",
     "@types/react-redux": "7.1.24",
     "@types/react-router-dom": "5.3.3",
     "axios": "0.26.1",

--- a/playground/src/hoc/recompose-examples.tsx
+++ b/playground/src/hoc/recompose-examples.tsx
@@ -9,7 +9,7 @@ type CounterOuterProps = {
 
 type CounterStateProps = {
   count: number;
-  setCount: (count: number) => number;
+  setCount: (count: number) => void;
 };
 
 type CounterHandlers = {

--- a/playground/src/hoc/recompose-examples.tsx
+++ b/playground/src/hoc/recompose-examples.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { compose, withHandlers, withProps, withState, withStateHandlers } from 'recompose';
+
+type CounterOuterProps = {
+  title: string;
+  initialCount?: number;
+  step?: number;
+};
+
+type CounterStateProps = {
+  count: number;
+  setCount: (count: number) => number;
+};
+
+type CounterHandlers = {
+  onIncrement: () => void;
+  onReset: () => void;
+};
+
+type CounterLabelProps = {
+  label: string;
+};
+
+type CounterProps = CounterOuterProps & CounterStateProps & CounterHandlers & CounterLabelProps;
+
+const CounterView: React.FC<CounterProps> = ({ count, label, onIncrement, onReset }) => (
+  <section>
+    <h3>{label}</h3>
+    <p>Current count: {count}</p>
+    <button type="button" onClick={onIncrement}>
+      Increment
+    </button>
+    <button type="button" onClick={onReset}>
+      Reset
+    </button>
+  </section>
+);
+
+const withCounterState = withState<CounterOuterProps, number, 'count', 'setCount'>(
+  'count',
+  'setCount',
+  ({ initialCount = 0 }) => initialCount
+);
+
+const withCounterHandlers = withHandlers<CounterOuterProps & CounterStateProps, CounterHandlers>({
+  onIncrement:
+    ({ count, setCount, step = 1 }) =>
+    () => {
+      setCount(count + step);
+    },
+  onReset:
+    ({ initialCount = 0, setCount }) =>
+    () => {
+      setCount(initialCount);
+    },
+});
+
+const withCounterLabel = withProps<
+  CounterLabelProps,
+  CounterOuterProps & CounterStateProps & CounterHandlers
+>(({ count, title }) => ({
+  label: `${title}: ${count}`,
+}));
+
+const enhanceCounter = compose<CounterProps, CounterOuterProps>(
+  withCounterState,
+  withCounterHandlers,
+  withCounterLabel
+);
+
+export const RecomposeCounter = enhanceCounter(CounterView);
+
+type ToggleOuterProps = {
+  label: string;
+  initiallyOpen?: boolean;
+};
+
+type ToggleState = {
+  isOpen: boolean;
+};
+
+type ToggleUpdaters = {
+  toggle: () => Partial<ToggleState>;
+  close: () => Partial<ToggleState>;
+};
+
+type ToggleProps = ToggleOuterProps & ToggleState & ToggleUpdaters;
+
+const ToggleView: React.FC<ToggleProps> = ({ close, isOpen, label, toggle }) => (
+  <section>
+    <button type="button" onClick={toggle}>
+      {label}
+    </button>
+    {isOpen && (
+      <button type="button" onClick={close}>
+        Close
+      </button>
+    )}
+  </section>
+);
+
+const withToggleState = withStateHandlers<ToggleState, ToggleUpdaters, ToggleOuterProps>(
+  ({ initiallyOpen = false }) => ({
+    isOpen: initiallyOpen,
+  }),
+  {
+    toggle:
+      ({ isOpen }) =>
+      () => ({
+        isOpen: !isOpen,
+      }),
+    close: () => () => ({
+      isOpen: false,
+    }),
+  }
+);
+
+export const RecomposeToggle = withToggleState(ToggleView);

--- a/playground/src/hoc/recompose-examples.usage.tsx
+++ b/playground/src/hoc/recompose-examples.usage.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+import { RecomposeCounter, RecomposeToggle } from './recompose-examples';
+
+export default () => (
+  <>
+    <RecomposeCounter title="Recompose counter" initialCount={3} step={2} />
+    <RecomposeToggle label="Show details" initiallyOpen />
+  </>
+);


### PR DESCRIPTION
## Description
Related to #46.

Adds a source-backed Recompose section to the Higher-Order Components part of the guide. The examples live in `playground/src/hoc`, are injected through `README_SOURCE.md`, and are included in the generated `README.md`.

This keeps the examples out of the runtime playground bundle. `recompose` itself declares React <=16 peer support, while this playground uses React 18.1, so this PR only adds `@types/recompose` for type-checking the examples.

Existing PRs cover useful parts of the request; this one focuses on the original source-backed/docs-generation path rather than inline README snippets. If maintainers prefer another PR or #94 as the base, I can port these changes there.

## Related issues:
- Related to #46

## Validation
- `npm run ci-check`
- `cd playground && npm ci`
- `cd playground && npm run tsc`
- `cd playground && npm run lint`
- `cd playground && CI=true npm run test -- --watchAll=false`
- `cd playground && npm run build`

Note: `node -e "require.resolve('recompose')"` fails as expected because this PR intentionally does not install the runtime package. The examples are source-backed/type-checked documentation snippets, not a runtime demo.

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/react-redux-typescript-guide/blob/master/CONTRIBUTING.md)
* [x] I have edited `README_SOURCE.md` (NOT `README.md`)
* [x] I have run CI script locally `npm run ci-check` to generate an updated `README.md`
* [x] I have linked all related issues above
* [x] I have rebased my branch


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#46: suggestion: recompose examples](https://oss.issuehunt.io/repos/76996763/issues/46)
---
</details>
<!-- /Issuehunt content-->