### PR TITLE
docs: add connect factory props example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ import { countersActions, countersSelectors } from '../features/counters';
 import { FCCounter } from '../components';
 
 type OwnProps = {
+  label: string;
   initialCount?: number;
 };
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
+    - [- Redux connected counter with factory props](#--redux-connected-counter-with-factory-props)
     - [- Redux connected counter via hooks](#--redux-connected-counter-via-hooks)
     - [- Redux connected counter with `redux-thunk` integration](#--redux-connected-counter-with-redux-thunk-integration)
   - [Context](#context)
@@ -1056,6 +1057,83 @@ export default () => (
     label={'FCCounterConnectedOwnProps'}
     initialCount={10}
   />
+);
+
+```
+</p></details>
+
+[⇧ back to top](#table-of-contents)
+
+### - Redux connected counter with factory props
+
+```tsx
+import Types from 'MyTypes';
+import { connect, MapStateToPropsFactory } from 'react-redux';
+
+import { countersActions, countersSelectors } from '../features/counters';
+import { FCCounter } from '../components';
+
+type OwnProps = {
+  initialCount?: number;
+};
+
+type StateProps = {
+  count: number;
+};
+
+const makeMapStateToProps: MapStateToPropsFactory<
+  StateProps,
+  OwnProps,
+  Types.RootState
+> = () => {
+  let previousCount: number | undefined;
+  let previousInitialCount: number | undefined;
+  let previousResult: StateProps | undefined;
+
+  return (state: Types.RootState, ownProps: OwnProps) => {
+    const count = countersSelectors.getReduxCounter(state.counters);
+    const initialCount = ownProps.initialCount || 0;
+
+    if (
+      previousResult &&
+      previousCount === count &&
+      previousInitialCount === initialCount
+    ) {
+      return previousResult;
+    }
+
+    previousCount = count;
+    previousInitialCount = initialCount;
+    previousResult = {
+      count: count + initialCount,
+    };
+
+    return previousResult;
+  };
+};
+
+const dispatchProps = {
+  onIncrement: countersActions.increment,
+};
+
+export const FCCounterConnectedFactory = connect(
+  makeMapStateToProps,
+  dispatchProps
+)(FCCounter);
+
+```
+<details><summary><i>Click to expand</i></summary><p>
+
+```tsx
+import * as React from 'react';
+
+import { FCCounterConnectedFactory } from './fc-counter-connected-factory';
+
+export default (
+  <div>
+    <FCCounterConnectedFactory label="Counter A" initialCount={10} />
+    <FCCounterConnectedFactory label="Counter B" initialCount={20} />
+  </div>
 );
 
 ```

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -111,6 +111,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Redux Connected Components](#redux-connected-components)
     - [- Redux connected counter](#--redux-connected-counter)
     - [- Redux connected counter with own props](#--redux-connected-counter-with-own-props)
+    - [- Redux connected counter with factory props](#--redux-connected-counter-with-factory-props)
     - [- Redux connected counter via hooks](#--redux-connected-counter-via-hooks)
     - [- Redux connected counter with `redux-thunk` integration](#--redux-connected-counter-with-redux-thunk-integration)
   - [Context](#context)
@@ -453,6 +454,13 @@ Adds error handling using componentDidCatch to any component
 
 ::codeblock='playground/src/connected/fc-counter-connected-own-props.tsx'::
 ::expander='playground/src/connected/fc-counter-connected-own-props.usage.tsx'::
+
+[⇧ back to top](#table-of-contents)
+
+### - Redux connected counter with factory props
+
+::codeblock='playground/src/connected/fc-counter-connected-factory.tsx'::
+::expander='playground/src/connected/fc-counter-connected-factory.usage.tsx'::
 
 [⇧ back to top](#table-of-contents)
 

--- a/playground/src/connected/fc-counter-connected-factory.tsx
+++ b/playground/src/connected/fc-counter-connected-factory.tsx
@@ -1,0 +1,53 @@
+import Types from 'MyTypes';
+import { connect, MapStateToPropsFactory } from 'react-redux';
+
+import { countersActions, countersSelectors } from '../features/counters';
+import { FCCounter } from '../components';
+
+type OwnProps = {
+  initialCount?: number;
+};
+
+type StateProps = {
+  count: number;
+};
+
+const makeMapStateToProps: MapStateToPropsFactory<
+  StateProps,
+  OwnProps,
+  Types.RootState
+> = () => {
+  let previousCount: number | undefined;
+  let previousInitialCount: number | undefined;
+  let previousResult: StateProps | undefined;
+
+  return (state: Types.RootState, ownProps: OwnProps) => {
+    const count = countersSelectors.getReduxCounter(state.counters);
+    const initialCount = ownProps.initialCount || 0;
+
+    if (
+      previousResult &&
+      previousCount === count &&
+      previousInitialCount === initialCount
+    ) {
+      return previousResult;
+    }
+
+    previousCount = count;
+    previousInitialCount = initialCount;
+    previousResult = {
+      count: count + initialCount,
+    };
+
+    return previousResult;
+  };
+};
+
+const dispatchProps = {
+  onIncrement: countersActions.increment,
+};
+
+export const FCCounterConnectedFactory = connect(
+  makeMapStateToProps,
+  dispatchProps
+)(FCCounter);

--- a/playground/src/connected/fc-counter-connected-factory.tsx
+++ b/playground/src/connected/fc-counter-connected-factory.tsx
@@ -5,6 +5,7 @@ import { countersActions, countersSelectors } from '../features/counters';
 import { FCCounter } from '../components';
 
 type OwnProps = {
+  label: string;
   initialCount?: number;
 };
 

--- a/playground/src/connected/fc-counter-connected-factory.usage.tsx
+++ b/playground/src/connected/fc-counter-connected-factory.usage.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+import { FCCounterConnectedFactory } from './fc-counter-connected-factory';
+
+export default (
+  <div>
+    <FCCounterConnectedFactory label="Counter A" initialCount={10} />
+    <FCCounterConnectedFactory label="Counter B" initialCount={20} />
+  </div>
+);

--- a/playground/src/connected/index.ts
+++ b/playground/src/connected/index.ts
@@ -1,3 +1,4 @@
 export * from './fc-counter-connected-bind-action-creators';
+export * from './fc-counter-connected-factory';
 export * from './fc-counter-connected-own-props';
 export * from './fc-counter-connected';


### PR DESCRIPTION
## Summary
- add a source-backed Redux connected counter example using `MapStateToPropsFactory`
- demonstrate per-instance memoization with `ownProps` while keeping inferred connected props type-safe
- include the example in `README_SOURCE.md` and regenerate `README.md`

Fixes #91

IssueHunt bounty: https://oss.issuehunt.io/r/piotrwitek/react-redux-typescript-guide/issues/91

## Verification
- `npm run ci-check`
- `cd playground && npm run lint`
- `cd playground && npm run tsc`
- `cd playground && CI=true npm test -- --watchAll=false`
- `git diff --check`


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#91: Factory types for connect props](https://oss.issuehunt.io/repos/76996763/issues/91)
---
</details>
<!-- /Issuehunt content-->