### PR TITLE
Add selector composition example for playground usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,10 +1069,13 @@ export default () => (
 import * as React from 'react';
 import { FCCounter } from '../components';
 import { increment } from '../features/counters/actions';
+import { countersSelectors } from '../features/counters';
 import { useSelector, useDispatch } from '../store/hooks';
 
 const FCCounterConnectedHooksUsage: React.FC = () => {
-  const counter = useSelector(state => state.counters.reduxCounter);
+  const counter = useSelector(state =>
+    countersSelectors.getReduxCounter(state.counters)
+  );
   const dispatch = useDispatch();
   return <FCCounter label="Use selector" count={counter} onIncrement={() => dispatch(increment())}/>;
 };
@@ -1762,6 +1765,20 @@ export const getFilteredTodos = createSelector(getTodos, getTodosFilter, (todos,
 
 ```
 
+```tsx
+import { countersSelectors } from '../features/counters';
+import { useSelector } from '../store/hooks';
+
+const selectReduxCounter = (state: RootState) =>
+  countersSelectors.getReduxCounter(state.counters);
+
+const counter = useSelector(selectReduxCounter);
+```
+
+The selector still belongs to the feature module, but the adapter function lives at
+the composition layer. This keeps the feature selector reusable while making the
+root-state-to-feature-state mapping explicit.
+
 [⇧ back to top](#table-of-contents)
 
 ---
@@ -1833,6 +1850,38 @@ export const useSelector: TypedUseSelectorHook<RootState> = useGenericSelector;
 
 export const useDispatch: () => Dispatch<RootAction> = useGenericDispatch;
 
+```
+
+<details><summary><i>Click to expand</i></summary><p>
+
+```tsx
+import * as React from 'react';
+import { FCCounter } from '../components';
+import { increment } from '../features/counters/actions';
+import { countersSelectors } from '../features/counters';
+import { useSelector, useDispatch } from '../store/hooks';
+
+const FCCounterConnectedHooksUsage: React.FC = () => {
+  const counter = useSelector(state =>
+    countersSelectors.getReduxCounter(state.counters)
+  );
+  const dispatch = useDispatch();
+  return <FCCounter label="Use selector" count={counter} onIncrement={() => dispatch(increment())}/>;
+};
+
+export default FCCounterConnectedHooksUsage;
+
+```
+</p></details>
+
+When a selector accepts feature state instead of root state, adapt it once at the
+call site:
+
+```tsx
+const selectReduxCounter = (state: RootState) =>
+  countersSelectors.getReduxCounter(state.counters);
+
+const counter = useSelector(selectReduxCounter);
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -1766,13 +1766,20 @@ export const getFilteredTodos = createSelector(getTodos, getTodosFilter, (todos,
 ```
 
 ```tsx
+import Types from 'MyTypes';
+import * as React from 'react';
+
 import { countersSelectors } from '../features/counters';
 import { useSelector } from '../store/hooks';
 
-const selectReduxCounter = (state: RootState) =>
+const selectReduxCounter = (state: Types.RootState) =>
   countersSelectors.getReduxCounter(state.counters);
 
-const counter = useSelector(selectReduxCounter);
+const CounterValue: React.FC = () => {
+  const counter = useSelector(selectReduxCounter);
+
+  return <span>{counter}</span>;
+};
 ```
 
 The selector still belongs to the feature module, but the adapter function lives at

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -657,13 +657,20 @@ state.containerObject.numbers.push(1); // TS Error: cannot use mutator methods
 ::codeblock='playground/src/features/todos/selectors.ts'::
 
 ```tsx
+import Types from 'MyTypes';
+import * as React from 'react';
+
 import { countersSelectors } from '../features/counters';
 import { useSelector } from '../store/hooks';
 
-const selectReduxCounter = (state: RootState) =>
+const selectReduxCounter = (state: Types.RootState) =>
   countersSelectors.getReduxCounter(state.counters);
 
-const counter = useSelector(selectReduxCounter);
+const CounterValue: React.FC = () => {
+  const counter = useSelector(selectReduxCounter);
+
+  return <span>{counter}</span>;
+};
 ```
 
 The selector still belongs to the feature module, but the adapter function lives at

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -656,6 +656,20 @@ state.containerObject.numbers.push(1); // TS Error: cannot use mutator methods
 
 ::codeblock='playground/src/features/todos/selectors.ts'::
 
+```tsx
+import { countersSelectors } from '../features/counters';
+import { useSelector } from '../store/hooks';
+
+const selectReduxCounter = (state: RootState) =>
+  countersSelectors.getReduxCounter(state.counters);
+
+const counter = useSelector(selectReduxCounter);
+```
+
+The selector still belongs to the feature module, but the adapter function lives at
+the composition layer. This keeps the feature selector reusable while making the
+root-state-to-feature-state mapping explicit.
+
 [⇧ back to top](#table-of-contents)
 
 ---
@@ -715,6 +729,18 @@ const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
 ### Typing `useSelector` and `useDispatch`
 
 ::codeblock='playground/src/store/hooks.ts'::
+
+::expander='playground/src/hooks/react-redux-hooks.tsx'::
+
+When a selector accepts feature state instead of root state, adapt it once at the
+call site:
+
+```tsx
+const selectReduxCounter = (state: RootState) =>
+  countersSelectors.getReduxCounter(state.counters);
+
+const counter = useSelector(selectReduxCounter);
+```
 
 [⇧ back to top](#table-of-contents)
 

--- a/playground/src/hooks/react-redux-hooks.tsx
+++ b/playground/src/hooks/react-redux-hooks.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import { FCCounter } from '../components';
 import { increment } from '../features/counters/actions';
+import { countersSelectors } from '../features/counters';
 import { useSelector, useDispatch } from '../store/hooks';
 
 const FCCounterConnectedHooksUsage: React.FC = () => {
-  const counter = useSelector(state => state.counters.reduxCounter);
+  const counter = useSelector(state =>
+    countersSelectors.getReduxCounter(state.counters)
+  );
   const dispatch = useDispatch();
   return <FCCounter label="Use selector" count={counter} onIncrement={() => dispatch(increment())}/>;
 };


### PR DESCRIPTION
Closes #109

## Summary
- show how to adapt `RootState` to feature state when reusing feature selectors
- update the hooks playground example to use `countersSelectors.getReduxCounter`
- document the selector composition pattern in the README

## Validation
- `npm run ci-check`
- `cd playground && npm run tsc`