### PR TITLE
Add typed connect factory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Connect with `react-redux`](#connect-with-react-redux)
     - [Typing connected component](#typing-connected-component)
     - [Typing `useSelector` and `useDispatch`](#typing-useselector-and-usedispatch)
+    - [Typing `connect` factory functions](#typing-connect-factory-functions)
     - [Typing connected component with `redux-thunk` integration](#typing-connected-component-with-redux-thunk-integration)
 - [Configuration & Dev Tools](#configuration--dev-tools)
   - [Common Npm Scripts](#common-npm-scripts)
@@ -1834,6 +1835,69 @@ export const useSelector: TypedUseSelectorHook<RootState> = useGenericSelector;
 export const useDispatch: () => Dispatch<RootAction> = useGenericDispatch;
 
 ```
+
+[⇧ back to top](#table-of-contents)
+
+### Typing `connect` factory functions
+
+When `connect` needs per-instance memoization, use a `MapStateToPropsFactory` so
+the factory and returned mapper are both type-checked.
+
+```tsx
+import Types from 'MyTypes';
+import { connect, MapStateToPropsFactory } from 'react-redux';
+
+import { countersActions, countersSelectors } from '../features/counters';
+import { FCCounter } from '../components';
+
+type OwnProps = {
+  initialCount?: number;
+};
+
+type StateProps = {
+  count: number;
+};
+
+const makeMapStateToProps: MapStateToPropsFactory<
+  StateProps,
+  OwnProps,
+  Types.RootState
+> = () => {
+  let offset = 0;
+
+  return (state, ownProps) => {
+    offset = ownProps.initialCount || 0;
+
+    return {
+      count: countersSelectors.getReduxCounter(state.counters) + offset,
+    };
+  };
+};
+
+const dispatchProps = {
+  onIncrement: countersActions.increment,
+};
+
+export const FCCounterConnectedFactory = connect(
+  makeMapStateToProps,
+  dispatchProps
+)(FCCounter);
+```
+
+<details><summary><i>Click to expand</i></summary><p>
+
+```tsx
+import * as React from 'react';
+
+import { FCCounterConnectedFactory } from './fc-counter-connected-factory';
+
+const FCCounterConnectedFactoryUsage: React.FC = () => (
+  <FCCounterConnectedFactory label="Factory props" initialCount={10} />
+);
+
+export default FCCounterConnectedFactoryUsage;
+```
+</p></details>
 
 [⇧ back to top](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -1862,16 +1862,12 @@ const makeMapStateToProps: MapStateToPropsFactory<
   StateProps,
   OwnProps,
   Types.RootState
-> = () => {
-  let offset = 0;
+> = (_, initialOwnProps) => {
+  const offset = initialOwnProps.initialCount || 0;
 
-  return (state, ownProps) => {
-    offset = ownProps.initialCount || 0;
-
-    return {
-      count: countersSelectors.getReduxCounter(state.counters) + offset,
-    };
-  };
+  return state => ({
+    count: countersSelectors.getReduxCounter(state.counters) + offset,
+  });
 };
 
 const dispatchProps = {

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -135,6 +135,7 @@ I highly recommend to add a bounty to the issue that you're waiting for to incre
   - [Connect with `react-redux`](#connect-with-react-redux)
     - [Typing connected component](#typing-connected-component)
     - [Typing `useSelector` and `useDispatch`](#typing-useselector-and-usedispatch)
+    - [Typing `connect` factory functions](#typing-connect-factory-functions)
     - [Typing connected component with `redux-thunk` integration](#typing-connected-component-with-redux-thunk-integration)
 - [Configuration & Dev Tools](#configuration--dev-tools)
   - [Common Npm Scripts](#common-npm-scripts)
@@ -715,6 +716,17 @@ const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
 ### Typing `useSelector` and `useDispatch`
 
 ::codeblock='playground/src/store/hooks.ts'::
+
+[⇧ back to top](#table-of-contents)
+
+### Typing `connect` factory functions
+
+When `connect` needs per-instance memoization, use a `MapStateToPropsFactory` so
+the factory and returned mapper are both type-checked.
+
+::codeblock='playground/src/connected/fc-counter-connected-factory.tsx'::
+
+::expander='playground/src/connected/fc-counter-connected-factory.usage.tsx'::
 
 [⇧ back to top](#table-of-contents)
 

--- a/playground/src/connected/fc-counter-connected-factory.tsx
+++ b/playground/src/connected/fc-counter-connected-factory.tsx
@@ -1,0 +1,38 @@
+import Types from 'MyTypes';
+import { connect, MapStateToPropsFactory } from 'react-redux';
+
+import { countersActions, countersSelectors } from '../features/counters';
+import { FCCounter } from '../components';
+
+type OwnProps = {
+  initialCount?: number;
+};
+
+type StateProps = {
+  count: number;
+};
+
+const makeMapStateToProps: MapStateToPropsFactory<
+  StateProps,
+  OwnProps,
+  Types.RootState
+> = () => {
+  let offset = 0;
+
+  return (state, ownProps) => {
+    offset = ownProps.initialCount || 0;
+
+    return {
+      count: countersSelectors.getReduxCounter(state.counters) + offset,
+    };
+  };
+};
+
+const dispatchProps = {
+  onIncrement: countersActions.increment,
+};
+
+export const FCCounterConnectedFactory = connect(
+  makeMapStateToProps,
+  dispatchProps
+)(FCCounter);

--- a/playground/src/connected/fc-counter-connected-factory.tsx
+++ b/playground/src/connected/fc-counter-connected-factory.tsx
@@ -16,16 +16,12 @@ const makeMapStateToProps: MapStateToPropsFactory<
   StateProps,
   OwnProps,
   Types.RootState
-> = () => {
-  let offset = 0;
+> = (_, initialOwnProps) => {
+  const offset = initialOwnProps.initialCount || 0;
 
-  return (state, ownProps) => {
-    offset = ownProps.initialCount || 0;
-
-    return {
-      count: countersSelectors.getReduxCounter(state.counters) + offset,
-    };
-  };
+  return state => ({
+    count: countersSelectors.getReduxCounter(state.counters) + offset,
+  });
 };
 
 const dispatchProps = {

--- a/playground/src/connected/fc-counter-connected-factory.usage.tsx
+++ b/playground/src/connected/fc-counter-connected-factory.usage.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+import { FCCounterConnectedFactory } from './fc-counter-connected-factory';
+
+const FCCounterConnectedFactoryUsage: React.FC = () => (
+  <FCCounterConnectedFactory label="Factory props" initialCount={10} />
+);
+
+export default FCCounterConnectedFactoryUsage;


### PR DESCRIPTION
Closes #91

## Summary
- add a typed `MapStateToPropsFactory` example for `connect`
- include a small usage example in the playground
- document the factory typing pattern in the README

## Validation
- `npm run ci-check`
- `cd playground && npm run tsc`