### PR TITLE
fix: narrow withConnectedCount own-props cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,10 +930,11 @@ export const withConnectedCount = <BaseProps extends InjectedProps>(
 
     render() {
       const { count, onIncrement, overrideCount, ...restProps } = this.props;
+      const ownProps = restProps as unknown as Diff<BaseProps, InjectedProps>;
 
       return (
         <BaseComponent
-          {...(restProps as BaseProps)}
+          {...(ownProps as BaseProps)}
           count={overrideCount || count} // injected
           onIncrement={onIncrement} // injected
         />

--- a/playground/src/hoc/with-connected-count.tsx
+++ b/playground/src/hoc/with-connected-count.tsx
@@ -35,10 +35,11 @@ export const withConnectedCount = <BaseProps extends InjectedProps>(
 
     render() {
       const { count, onIncrement, overrideCount, ...restProps } = this.props;
+      const ownProps = restProps as unknown as Diff<BaseProps, InjectedProps>;
 
       return (
         <BaseComponent
-          {...(restProps as BaseProps)}
+          {...(ownProps as BaseProps)}
           count={overrideCount || count} // injected
           onIncrement={onIncrement} // injected
         />


### PR DESCRIPTION
## Summary
- cast the stripped `restProps` to `Diff<BaseProps, InjectedProps>` before passing it through the JSX spread
- keep the injected `count` / `onIncrement` props supplied separately at the call site
- regenerate the README output so the published snippet matches the playground source

## Validation
- `npm run ci-check`
- `cd playground && CI=true npm run tsc`
- `cd playground && npm run lint`

Closes #204
