### PR TITLE
fix: make WithConnectedCount usage incrementable

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,7 +966,7 @@ import { FCCounter } from '../components';
 const FCCounterWithConnectedCount = withConnectedCount(FCCounter);
 
 export default () => (
-  <FCCounterWithConnectedCount overrideCount={5} label={'FCCounterWithState'} />
+  <FCCounterWithConnectedCount label={'FCCounterWithConnectedCount'} />
 );
 
 ```

--- a/playground/src/hoc/with-connected-count.usage.tsx
+++ b/playground/src/hoc/with-connected-count.usage.tsx
@@ -6,5 +6,5 @@ import { FCCounter } from '../components';
 const FCCounterWithConnectedCount = withConnectedCount(FCCounter);
 
 export default () => (
-  <FCCounterWithConnectedCount overrideCount={5} label={'FCCounterWithState'} />
+  <FCCounterWithConnectedCount label={'FCCounterWithConnectedCount'} />
 );


### PR DESCRIPTION
## Summary
- remove the hard-coded `overrideCount={5}` from the `WithConnectedCountUsage` example
- correct the example label to match the connected HOC example
- regenerate the README output so the docs show the working usage snippet

## Validation
- `npm run ci-check`
- `cd playground && CI=true npm run tsc`
- `cd playground && npm run lint`

Closes #211
