### PR TITLE
fix: make bindActionCreators thunk example runnable

### DIFF
--- a/playground/src/connected/fc-counter-connected-bind-action-creators.spec.tsx
+++ b/playground/src/connected/fc-counter-connected-bind-action-creators.spec.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { AnyAction, applyMiddleware, combineReducers, createStore } from 'redux';
 import thunk from 'redux-thunk';
 
 import { FCCounterConnectedBindActionCreators as ConnectedCounter } from './fc-counter-connected-bind-action-creators';
 
 const reducer = combineReducers({
   counters: combineReducers({
-    reduxCounter: (state: number = 0, action: any) => {
+    reduxCounter: (state: number = 0, action: AnyAction) => {
       switch (action.type) {
         case 'counters/INCREMENT':
           return state + 1;
@@ -22,7 +22,6 @@ const reducer = combineReducers({
 
 afterEach(() => {
   jest.useRealTimers();
-  cleanup();
 });
 
 test('can dispatch the delayed increment thunk', async () => {
@@ -31,14 +30,14 @@ test('can dispatch the delayed increment thunk', async () => {
   const label = 'Counter 1';
   renderWithRedux(<ConnectedCounter label={label} />);
 
+  expect(screen.getByText(`${label}: 0`)).toBeTruthy();
   fireEvent.click(screen.getByText('Increment'));
-  expect(screen.getByText(RegExp(label)).textContent).toBe(label + ': 0');
 
   await act(async () => {
     jest.advanceTimersByTime(1000);
   });
 
-  expect(screen.getByText(RegExp(label)).textContent).toBe(label + ': 1');
+  expect(screen.getByText(`${label}: 1`)).toBeTruthy();
 });
 
 function renderWithRedux(

--- a/playground/src/connected/fc-counter-connected-bind-action-creators.spec.tsx
+++ b/playground/src/connected/fc-counter-connected-bind-action-creators.spec.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import thunk from 'redux-thunk';
+
+import { FCCounterConnectedBindActionCreators as ConnectedCounter } from './fc-counter-connected-bind-action-creators';
+
+const reducer = combineReducers({
+  counters: combineReducers({
+    reduxCounter: (state: number = 0, action: any) => {
+      switch (action.type) {
+        case 'counters/INCREMENT':
+          return state + 1;
+
+        default:
+          return state;
+      }
+    },
+  }),
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  cleanup();
+});
+
+test('can dispatch the delayed increment thunk', async () => {
+  jest.useFakeTimers();
+
+  const label = 'Counter 1';
+  renderWithRedux(<ConnectedCounter label={label} />);
+
+  fireEvent.click(screen.getByText('Increment'));
+  expect(screen.getByText(RegExp(label)).textContent).toBe(label + ': 0');
+
+  await act(async () => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  expect(screen.getByText(RegExp(label)).textContent).toBe(label + ': 1');
+});
+
+function renderWithRedux(
+  jsx: JSX.Element,
+  options: { initialState?: object } = {}
+) {
+  const store = createStore(
+    reducer,
+    options.initialState,
+    applyMiddleware(thunk)
+  );
+
+  return render(<Provider store={store}>{jsx}</Provider>);
+}

--- a/playground/src/store/store.ts
+++ b/playground/src/store/store.ts
@@ -1,6 +1,7 @@
 import { RootAction, RootState, Services } from 'MyTypes';
 import { applyMiddleware, createStore } from 'redux';
 import { createEpicMiddleware } from 'redux-observable';
+import thunk from 'redux-thunk';
 
 import services from '../services';
 import { routerMiddleware } from './redux-router';
@@ -18,7 +19,7 @@ const epicMiddleware = createEpicMiddleware<
 });
 
 // configure middlewares
-const middlewares = [epicMiddleware, routerMiddleware];
+const middlewares = [thunk, epicMiddleware, routerMiddleware];
 // compose enhancers
 const enhancer = composeEnhancers(applyMiddleware(...middlewares));
 


### PR DESCRIPTION
## Summary
- add `redux-thunk` to the playground store middleware chain so the delayed counter example can dispatch thunks at runtime
- add a regression test covering the `FCCounterConnectedBindActionCreators` increment flow

## Validation
- `cd playground && export CI=true && npm test -- --runInBand --watch=false src/connected/fc-counter-connected-bind-action-creators.spec.tsx`
- `cd playground && npm run tsc`
- `cd playground && npx eslint src/store/store.ts src/connected/fc-counter-connected-bind-action-creators.spec.tsx`

Closes #212