### PR TITLE
docs: refresh outdated bindActionCreators example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1780,9 +1780,9 @@ import { connect } from 'react-redux';
 import { countersActions } from '../features/counters';
 import { FCCounter } from '../components';
 
-// Type annotation for "state" argument is mandatory to check 
-// the correct shape of state object and injected props you can also
-// extend connected component Props interface by annotating `ownProps` argument
+// Annotating the `state` argument checks the root-state shape.
+// You can also extend the connected component props interface by
+// annotating the `ownProps` argument.
 const mapStateToProps = (state: MyTypes.RootState, ownProps: FCCounterProps) => ({
   count: state.counters.reduxCounter,
 });
@@ -1794,10 +1794,10 @@ const dispatchProps = {
   onIncrement: countersActions.increment,
 };
 
-// Notice we don't need to pass any generic type parameters to neither
-// the connect function below nor map functions declared above
-// because type inference will infer types from arguments annotations automatically
-// This is much cleaner and idiomatic approach
+// Notice that we do not need to pass explicit generic parameters to
+// `connect` or to the mapping functions declared above.
+// Type inference derives them automatically from the annotated inputs,
+// which keeps the example cleaner and more idiomatic.
 export const FCCounterConnected =
   connect(mapStateToProps, dispatchProps)(FCCounter);
 

--- a/README.md
+++ b/README.md
@@ -1775,7 +1775,6 @@ _**NOTE**: Below you'll find a short explanation of concepts behind using `conne
 ```tsx
 import MyTypes from 'MyTypes';
 
-import { bindActionCreators, Dispatch, ActionCreatorsMapObject } from 'redux';
 import { connect } from 'react-redux';
 
 import { countersActions } from '../features/counters';
@@ -1788,16 +1787,11 @@ const mapStateToProps = (state: MyTypes.RootState, ownProps: FCCounterProps) => 
   count: state.counters.reduxCounter,
 });
 
-// "dispatch" argument needs an annotation to check the correct shape
-//  of an action object when using dispatch function
-const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
-  bindActionCreators({
-    onIncrement: countersActions.increment,
-  }, dispatch);
-
-// shorter alternative is to use an object instead of mapDispatchToProps function
-const dispatchToProps = {
-    onIncrement: countersActions.increment,
+// Prefer the object shorthand for plain action creators.
+// It keeps the example aligned with current react-redux usage and
+// still infers the injected prop types correctly.
+const dispatchProps = {
+  onIncrement: countersActions.increment,
 };
 
 // Notice we don't need to pass any generic type parameters to neither
@@ -1805,14 +1799,10 @@ const dispatchToProps = {
 // because type inference will infer types from arguments annotations automatically
 // This is much cleaner and idiomatic approach
 export const FCCounterConnected =
-  connect(mapStateToProps, mapDispatchToProps)(FCCounter);
+  connect(mapStateToProps, dispatchProps)(FCCounter);
 
-// You can add extra layer of validation of your action creators
-// by using bindActionCreators generic type parameter and RootAction type
-const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
-  bindActionCreators<ActionCreatorsMapObject<Types.RootAction>>({
-    invalidActionCreator: () => 1, // Error: Type 'number' is not assignable to type '{ type: "todos/ADD"; payload: Todo; } | { ... }
-  }, dispatch);
+// Keep the function form when you need access to `dispatch`
+// directly (for example in the thunk integration example below).
 
 ```
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -669,7 +669,6 @@ _**NOTE**: Below you'll find a short explanation of concepts behind using `conne
 ```tsx
 import MyTypes from 'MyTypes';
 
-import { bindActionCreators, Dispatch, ActionCreatorsMapObject } from 'redux';
 import { connect } from 'react-redux';
 
 import { countersActions } from '../features/counters';
@@ -682,16 +681,11 @@ const mapStateToProps = (state: MyTypes.RootState, ownProps: FCCounterProps) => 
   count: state.counters.reduxCounter,
 });
 
-// "dispatch" argument needs an annotation to check the correct shape
-//  of an action object when using dispatch function
-const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
-  bindActionCreators({
-    onIncrement: countersActions.increment,
-  }, dispatch);
-
-// shorter alternative is to use an object instead of mapDispatchToProps function
-const dispatchToProps = {
-    onIncrement: countersActions.increment,
+// Prefer the object shorthand for plain action creators.
+// It keeps the example aligned with current react-redux usage and
+// still infers the injected prop types correctly.
+const dispatchProps = {
+  onIncrement: countersActions.increment,
 };
 
 // Notice we don't need to pass any generic type parameters to neither
@@ -699,14 +693,10 @@ const dispatchToProps = {
 // because type inference will infer types from arguments annotations automatically
 // This is much cleaner and idiomatic approach
 export const FCCounterConnected =
-  connect(mapStateToProps, mapDispatchToProps)(FCCounter);
+  connect(mapStateToProps, dispatchProps)(FCCounter);
 
-// You can add extra layer of validation of your action creators
-// by using bindActionCreators generic type parameter and RootAction type
-const mapDispatchToProps = (dispatch: Dispatch<MyTypes.RootAction>) =>
-  bindActionCreators<ActionCreatorsMapObject<Types.RootAction>>({
-    invalidActionCreator: () => 1, // Error: Type 'number' is not assignable to type '{ type: "todos/ADD"; payload: Todo; } | { ... }
-  }, dispatch);
+// Keep the function form when you need access to `dispatch`
+// directly (for example in the thunk integration example below).
 
 ```
 

--- a/README_SOURCE.md
+++ b/README_SOURCE.md
@@ -674,9 +674,9 @@ import { connect } from 'react-redux';
 import { countersActions } from '../features/counters';
 import { FCCounter } from '../components';
 
-// Type annotation for "state" argument is mandatory to check 
-// the correct shape of state object and injected props you can also
-// extend connected component Props interface by annotating `ownProps` argument
+// Annotating the `state` argument checks the root-state shape.
+// You can also extend the connected component props interface by
+// annotating the `ownProps` argument.
 const mapStateToProps = (state: MyTypes.RootState, ownProps: FCCounterProps) => ({
   count: state.counters.reduxCounter,
 });
@@ -688,10 +688,10 @@ const dispatchProps = {
   onIncrement: countersActions.increment,
 };
 
-// Notice we don't need to pass any generic type parameters to neither
-// the connect function below nor map functions declared above
-// because type inference will infer types from arguments annotations automatically
-// This is much cleaner and idiomatic approach
+// Notice that we do not need to pass explicit generic parameters to
+// `connect` or to the mapping functions declared above.
+// Type inference derives them automatically from the annotated inputs,
+// which keeps the example cleaner and more idiomatic.
 export const FCCounterConnected =
   connect(mapStateToProps, dispatchProps)(FCCounter);
 


### PR DESCRIPTION
## Summary
- replace the outdated basic `bindActionCreators` example with the object shorthand that current `react-redux` usage already supports
- remove the stale generic-validation snippet that no longer reflects the guide's current recommendations
- regenerate `README.md` from `README_SOURCE.md`

## Validation
- `npm run ci-check`

Closes #203